### PR TITLE
Support graph building from a module path

### DIFF
--- a/amalgamate.py
+++ b/amalgamate.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import pprint
+import importlib
 from itertools import repeat
 from collections import namedtuple
 from collections.abc import Mapping
@@ -254,6 +255,35 @@ def make_graph(pkg, exclude=None):
         graph[base] = make_node(base, pkg, allowed, glbnames)
     glbnames.warn_duplicates()
     return graph
+
+
+def graph_from_module(modpath, exclude=None):
+    """Return a deps graph and the pkg file path given a module path.
+    """
+    graph = {}
+    allowed = set()
+    mod = importlib.import_module(modpath)
+    modfile = mod.__file__
+    pkg = os.path.dirname(modfile)
+    if '__init__.py' in modfile:  # pkg mod
+        files = os.listdir(pkg)
+    else:  # single module
+        files = [os.path.basename(modfile)]
+
+    for fname in files:
+        base, ext = os.path.splitext(fname)
+        if base != '__init__' and (base.startswith('__') or ext != '.py'):
+            continue
+        allowed.add(base)
+
+    if exclude:
+        allowed -= exclude
+
+    glbnames = GlobalNames(pkg=pkg)
+    for base in allowed:
+        graph[base] = make_node(base, pkg, allowed, glbnames)
+    glbnames.warn_duplicates()
+    return graph, pkg
 
 
 def depsort(graph):


### PR DESCRIPTION
@scopatz I realize there's a bit of duplication here with `make_graph()` (which I'm hoping you can help me factor out) but I needed a way to be able to hand in a simple module path so that I can use `amalgamate` to compile code to ship to remote systems using [`execnet`](http://codespeak.net/execnet/basics.html).

Let me know what you think and what tests I should write if needed.
Thanks!